### PR TITLE
consul_encrypt_keys should be an array of keys

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,9 +49,10 @@ func CreateVars(dnsName, mysqlHost string) (OutputData, error) {
 		"uaa_clients_tcp_emitter_secret",
 		"uaa_clients_tcp_router_secret",
 		"uaa_login_client_secret",
-		"consul_encrypt_keys",
 		"diego_bbs_encryption_keys_passphrase",
 	)
+
+	o.GeneratePasswordArray("consul_encrypt_keys", 1)
 
 	o["uaa_scim_users_admin_name"] = "admin"
 	o["blobstore_admin_users_username"] = "blobstore-user"

--- a/generate.go
+++ b/generate.go
@@ -21,7 +21,7 @@ const (
 	CfgWithHTTPSURL
 )
 
-type OutputData map[string]string
+type OutputData map[string]interface{}
 
 func (o OutputData) AddSystemComponent(name string, cfgFlags int) {
 	sysDomain := o["system_domain"]
@@ -48,6 +48,14 @@ func (o OutputData) GeneratePasswords(keynames ...string) {
 	for _, name := range keynames {
 		o[name] = generatePassword()
 	}
+}
+
+func (o OutputData) GeneratePasswordArray(keyName string, numKeys int) {
+	var passwords []string
+	for i := 0; i < numKeys; i++ {
+		passwords = append(passwords, generatePassword())
+	}
+	o[keyName] = passwords
 }
 
 func (o OutputData) GeneratePlainKeyPair(plainKeyPair *PlainKeyPair) error {


### PR DESCRIPTION
... instead of a single string.

I had to change the map to be `map[string]interface{}`, which I'm not a fan of, but I couldn't really see a way around it.